### PR TITLE
Feature/2 경매 등록 & S3 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // AWS S3
+    implementation 'software.amazon.awssdk:s3:2.22.2'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
@@ -7,11 +7,16 @@ import kr.gravy.gravystudy.auth.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -20,10 +25,11 @@ public class AuctionController {
 
     private final AuctionService auctionService;
 
-    @PostMapping("/api/v1/auctions")
-    public ResponseEntity<AuctionRegistrationDto.Response> registerAuction(@AuthenticationPrincipal User user,
-                                                                           @Valid @RequestBody AuctionRegistrationDto.Request request) {
-        AuctionRegistrationDto.Response response = auctionService.registerAuction(user, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    @PostMapping(value = "/api/v1/auctions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<AuctionRegistrationDto.Response> registerAuction(
+            @AuthenticationPrincipal User user,
+            @Valid @ModelAttribute AuctionRegistrationDto.Request request,
+            @RequestPart(value = "image", required = false) List<MultipartFile> images) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(auctionService.registerAuction(user, request, images));
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
@@ -1,0 +1,29 @@
+package kr.gravy.gravystudy.auction.controller;
+
+import jakarta.validation.Valid;
+import kr.gravy.gravystudy.auction.dto.AuctionRegistrationDto;
+import kr.gravy.gravystudy.auction.service.AuctionService;
+import kr.gravy.gravystudy.auth.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuctionController {
+
+    private final AuctionService auctionService;
+
+    @PostMapping("/api/v1/auctions")
+    public ResponseEntity<AuctionRegistrationDto.Response> registerAuction(@AuthenticationPrincipal User user,
+                                                                           @Valid @RequestBody AuctionRegistrationDto.Request request) {
+        AuctionRegistrationDto.Response response = auctionService.registerAuction(user, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionRegistrationDto.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionRegistrationDto.java
@@ -7,6 +7,7 @@ import kr.gravy.gravystudy.auction.model.Category;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class AuctionRegistrationDto {
@@ -31,7 +32,8 @@ public class AuctionRegistrationDto {
             Long minBidIncrement,
             LocalDateTime auctionStartTime,
             LocalDateTime auctionEndTime,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            List<String> imageUrls
     ) {
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionRegistrationDto.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionRegistrationDto.java
@@ -1,0 +1,37 @@
+package kr.gravy.gravystudy.auction.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import kr.gravy.gravystudy.auction.model.Category;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AuctionRegistrationDto {
+
+    public record Request(
+            @NotBlank(message = "상품 제목은 필수입니다.") String title,
+            @NotBlank(message = "상품 설명은 필수입니다.") String description,
+            @NotNull(message = "카테고리는 필수입니다.") Category category,
+            @NotNull(message = "시작 가격은 필수입니다.") @Positive(message = "시작 가격은 0보다 커야 합니다.") Long startingPrice,
+            @NotNull(message = "최소 입찰 단위는 필수입니다.") @Positive(message = "최소 입찰 단위는 0보다 커야 합니다.") Long minBidIncrement,
+            @NotNull(message = "경매 시작 시간은 필수입니다.") LocalDateTime auctionStartTime,
+            @NotNull(message = "경매 종료 시간은 필수입니다.") LocalDateTime auctionEndTime
+    ) {
+    }
+
+    public record Response(
+            Long id,
+            String title,
+            String description,
+            Category category,
+            Long startingPrice,
+            Long minBidIncrement,
+            LocalDateTime auctionStartTime,
+            LocalDateTime auctionEndTime,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/entity/Auction.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/entity/Auction.java
@@ -1,6 +1,8 @@
 package kr.gravy.gravystudy.auction.entity;
 
 import kr.gravy.gravystudy.auction.model.Category;
+import kr.gravy.gravystudy.common.exception.GravyException;
+import kr.gravy.gravystudy.common.exception.Status;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,6 +56,7 @@ public class Auction {
             LocalDateTime auctionEndTime,
             LocalDateTime createdAt
     ) {
+        validateAuctionTime(auctionStartTime, auctionEndTime, createdAt);
         return new Auction(
                 sellerId,
                 title,
@@ -65,5 +68,15 @@ public class Auction {
                 auctionEndTime,
                 createdAt
         );
+    }
+
+    private static void validateAuctionTime(LocalDateTime startTime, LocalDateTime endTime, LocalDateTime createdAt) {
+        if (startTime.isBefore(createdAt)) {
+            throw new GravyException(Status.INVALID_AUCTION_START_TIME);
+        }
+
+        if (endTime.isBefore(startTime) || endTime.isEqual(startTime)) {
+            throw new GravyException(Status.INVALID_AUCTION_END_TIME);
+        }
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/entity/Auction.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/entity/Auction.java
@@ -1,0 +1,69 @@
+package kr.gravy.gravystudy.auction.entity;
+
+import kr.gravy.gravystudy.auction.model.Category;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Auction {
+    private Long id;
+    private Long sellerId;
+    private String title;
+    private String description;
+    private Category category;
+    private Long startingPrice;
+    private Long minBidIncrement;
+    private LocalDateTime auctionStartTime;
+    private LocalDateTime auctionEndTime;
+    private LocalDateTime createdAt;
+
+    private Auction(
+            Long sellerId,
+            String title,
+            String description,
+            Category category,
+            Long startingPrice,
+            Long minBidIncrement,
+            LocalDateTime auctionStartTime,
+            LocalDateTime auctionEndTime,
+            LocalDateTime createdAt
+    ) {
+        this.sellerId = sellerId;
+        this.title = title;
+        this.description = description;
+        this.category = category;
+        this.startingPrice = startingPrice;
+        this.minBidIncrement = minBidIncrement;
+        this.auctionStartTime = auctionStartTime;
+        this.auctionEndTime = auctionEndTime;
+        this.createdAt = createdAt;
+    }
+
+    public static Auction createForRegistration(
+            Long sellerId,
+            String title,
+            String description,
+            Category category,
+            Long startingPrice,
+            Long minBidIncrement,
+            LocalDateTime auctionStartTime,
+            LocalDateTime auctionEndTime,
+            LocalDateTime createdAt
+    ) {
+        return new Auction(
+                sellerId,
+                title,
+                description,
+                category,
+                startingPrice,
+                minBidIncrement,
+                auctionStartTime,
+                auctionEndTime,
+                createdAt
+        );
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/entity/AuctionImage.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/entity/AuctionImage.java
@@ -1,0 +1,29 @@
+package kr.gravy.gravystudy.auction.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuctionImage {
+
+    private Long id;
+    private Long auctionId;
+    private String imageUrl;
+    private int displayOrder;
+    private LocalDateTime createdAt;
+
+    private AuctionImage(Long auctionId, String imageUrl, int displayOrder, LocalDateTime createdAt) {
+        this.auctionId = auctionId;
+        this.imageUrl = imageUrl;
+        this.displayOrder = displayOrder;
+        this.createdAt = createdAt;
+    }
+
+    public static AuctionImage create(Long auctionId, String imageUrl, int displayOrder, LocalDateTime createdAt) {
+        return new AuctionImage(auctionId, imageUrl, displayOrder, createdAt);
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionImageMapper.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionImageMapper.java
@@ -1,0 +1,8 @@
+package kr.gravy.gravystudy.auction.mapper;
+
+import kr.gravy.gravystudy.auction.entity.AuctionImage;
+
+public interface AuctionImageMapper {
+
+    void insertAuctionImage(AuctionImage auctionImage);
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionMapper.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionMapper.java
@@ -1,0 +1,8 @@
+package kr.gravy.gravystudy.auction.mapper;
+
+import kr.gravy.gravystudy.auction.entity.Auction;
+
+public interface AuctionMapper {
+
+    void insertAuction(Auction auction);
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/model/Category.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/model/Category.java
@@ -1,0 +1,30 @@
+package kr.gravy.gravystudy.auction.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    DIGITAL_DEVICE("디지털기기"),
+    HOME_APPLIANCES("생활가전"),
+    FURNITURE_INTERIOR("가구/인테리어"),
+    LIVING_KITCHEN("생활/주방"),
+    INFANT_CHILD("유아동"),
+    INFANT_BOOKS("유아도서"),
+    WOMEN_CLOTHING("여성의류"),
+    WOMEN_ACCESSORIES("여성잡화"),
+    MEN_FASHION_ACCESSORIES("남성패션/잡화"),
+    BEAUTY_CARE("뷰티/미용"),
+    SPORTS_LEISURE("스포츠/레저"),
+    HOBBY_GAME_MUSIC("취미/게임/음반"),
+    BOOKS("도서"),
+    TICKETS_VOUCHERS("티켓/교환권"),
+    PROCESSED_FOOD("가공식품"),
+    HEALTH_SUPPLEMENTS("건강기능식품"),
+    PET_SUPPLIES("반려동물용품"),
+    PLANTS("식물"),
+    OTHER_USED_GOODS("기타 중고물품");
+
+    private final String explanation;
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
@@ -2,16 +2,20 @@ package kr.gravy.gravystudy.auction.service;
 
 import kr.gravy.gravystudy.auction.dto.AuctionRegistrationDto;
 import kr.gravy.gravystudy.auction.entity.Auction;
+import kr.gravy.gravystudy.auction.entity.AuctionImage;
+import kr.gravy.gravystudy.auction.mapper.AuctionImageMapper;
 import kr.gravy.gravystudy.auction.mapper.AuctionMapper;
 import kr.gravy.gravystudy.auth.entity.User;
-import kr.gravy.gravystudy.common.exception.GravyException;
-import kr.gravy.gravystudy.common.exception.Status;
+import kr.gravy.gravystudy.infrastructure.aws.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -19,11 +23,17 @@ import java.time.LocalDateTime;
 public class AuctionService {
 
     private final AuctionMapper auctionMapper;
+    private final AuctionImageMapper auctionImageMapper;
+    private final S3Service s3Service;
 
     @Transactional
-    public AuctionRegistrationDto.Response registerAuction(final User user, final AuctionRegistrationDto.Request request) {
+    public AuctionRegistrationDto.Response registerAuction(
+            final User user,
+            final AuctionRegistrationDto.Request request,
+            final List<MultipartFile> images) {
+
         LocalDateTime now = LocalDateTime.now();
-        validateAuctionTime(request.auctionStartTime(), request.auctionEndTime());
+        validateImagesIfPresent(images);
 
         Auction auction = Auction.createForRegistration(
                 user.getId(),
@@ -36,8 +46,9 @@ public class AuctionService {
                 request.auctionEndTime(),
                 now
         );
-
         auctionMapper.insertAuction(auction);
+
+        List<String> imageUrls = uploadAndSaveImages(auction.getId(), images, now);
 
         return new AuctionRegistrationDto.Response(
                 auction.getId(),
@@ -48,19 +59,52 @@ public class AuctionService {
                 auction.getMinBidIncrement(),
                 auction.getAuctionStartTime(),
                 auction.getAuctionEndTime(),
-                auction.getCreatedAt()
+                auction.getCreatedAt(),
+                imageUrls
         );
     }
 
-    private void validateAuctionTime(LocalDateTime startTime, LocalDateTime endTime) {
-        LocalDateTime now = LocalDateTime.now();
+    private void validateImagesIfPresent(List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) {
+            return;
+        }
+        s3Service.validatePossibleUploadImages(images);
+    }
 
-        if (startTime.isBefore(now)) {
-            throw new GravyException(Status.INVALID_AUCTION_START_TIME);
+    private List<String> uploadAndSaveImages(Long auctionId, List<MultipartFile> images, LocalDateTime now) {
+        if (images == null || images.isEmpty()) {
+            return List.of();
         }
 
-        if (endTime.isBefore(startTime) || endTime.isEqual(startTime)) {
-            throw new GravyException(Status.INVALID_AUCTION_END_TIME);
+        List<String> uploadedUrls = new ArrayList<>();
+        try {
+            for (int order = 0; order < images.size(); order++) {
+                MultipartFile file = images.get(order);
+
+                // S3 업로드
+                String imageUrl = s3Service.uploadFile(file);
+                uploadedUrls.add(imageUrl);
+
+                AuctionImage auctionImage = AuctionImage.create(auctionId, imageUrl, order, now);
+                auctionImageMapper.insertAuctionImage(auctionImage);
+            }
+            return uploadedUrls;
+        } catch (Exception e) {
+            // 업로드 실패 시 이미 업로드된 S3 파일들 삭제
+            log.error("이미지 업로드 중 오류 발생 - {} 개 파일 롤백 중", uploadedUrls.size());
+            rollbackUploadedImages(uploadedUrls);
+            throw e;
+        }
+    }
+
+    private void rollbackUploadedImages(List<String> imageUrls) {
+        for (String imageUrl : imageUrls) {
+            try {
+                s3Service.deleteFile(imageUrl);
+                log.info("S3 롤백 성공: {}", imageUrl);
+            } catch (Exception e) {
+                log.error("S3 롤백 실패 (수동 처리 필요): {}", imageUrl, e);
+            }
         }
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
@@ -1,0 +1,66 @@
+package kr.gravy.gravystudy.auction.service;
+
+import kr.gravy.gravystudy.auction.dto.AuctionRegistrationDto;
+import kr.gravy.gravystudy.auction.entity.Auction;
+import kr.gravy.gravystudy.auction.mapper.AuctionMapper;
+import kr.gravy.gravystudy.auth.entity.User;
+import kr.gravy.gravystudy.common.exception.GravyException;
+import kr.gravy.gravystudy.common.exception.Status;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuctionService {
+
+    private final AuctionMapper auctionMapper;
+
+    @Transactional
+    public AuctionRegistrationDto.Response registerAuction(final User user, final AuctionRegistrationDto.Request request) {
+        LocalDateTime now = LocalDateTime.now();
+        validateAuctionTime(request.auctionStartTime(), request.auctionEndTime());
+
+        Auction auction = Auction.createForRegistration(
+                user.getId(),
+                request.title(),
+                request.description(),
+                request.category(),
+                request.startingPrice(),
+                request.minBidIncrement(),
+                request.auctionStartTime(),
+                request.auctionEndTime(),
+                now
+        );
+
+        auctionMapper.insertAuction(auction);
+
+        return new AuctionRegistrationDto.Response(
+                auction.getId(),
+                auction.getTitle(),
+                auction.getDescription(),
+                auction.getCategory(),
+                auction.getStartingPrice(),
+                auction.getMinBidIncrement(),
+                auction.getAuctionStartTime(),
+                auction.getAuctionEndTime(),
+                auction.getCreatedAt()
+        );
+    }
+
+    private void validateAuctionTime(LocalDateTime startTime, LocalDateTime endTime) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (startTime.isBefore(now)) {
+            throw new GravyException(Status.INVALID_AUCTION_START_TIME);
+        }
+
+        if (endTime.isBefore(startTime) || endTime.isEqual(startTime)) {
+            throw new GravyException(Status.INVALID_AUCTION_END_TIME);
+        }
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auth/configuration/WebMvcConfiguration.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/configuration/WebMvcConfiguration.java
@@ -1,0 +1,21 @@
+package kr.gravy.gravystudy.auth.configuration;
+
+import kr.gravy.gravystudy.auth.resolver.AuthenticationUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    private final AuthenticationUserArgumentResolver authenticationUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationUserArgumentResolver);
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auth/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/jwt/JWTAuthenticationFilter.java
@@ -1,15 +1,13 @@
 package kr.gravy.gravystudy.auth.jwt;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kr.gravy.gravystudy.auth.mapper.UserMapper;
 import kr.gravy.gravystudy.auth.model.Grade;
 import kr.gravy.gravystudy.auth.utils.CookieUtil;
-import kr.gravy.gravystudy.common.exception.GravyException;
-import kr.gravy.gravystudy.common.exception.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,8 +27,6 @@ import java.util.UUID;
 public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
-    private final UserMapper userMapper;
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
@@ -51,9 +47,15 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            UUID userPublicId = jwtUtil.validateAndGetSubjectAsUUID(token);
-            Grade grade = userMapper.getUserGradeByPublicId(userPublicId)
-                    .orElseThrow(() -> new GravyException(Status.USER_NOT_FOUND));
+            Claims claims = jwtUtil.validateAndGetClaims(token);
+
+            /** TODO:: 프로젝트에서 코드 제거 (JWT 장점 극대화)
+             * User user = userMapper.getUserByPublicId(userPublicId)
+             *                     .orElseThrow(() -> new GravyException(Status.USER_NOT_FOUND));
+             */
+
+            UUID userPublicId = UUID.fromString(claims.getSubject());
+            Grade grade = Grade.valueOf(claims.get("grade", String.class));
 
             List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + grade.name()));
 

--- a/src/main/java/kr/gravy/gravystudy/auth/jwt/JWTUtil.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/jwt/JWTUtil.java
@@ -1,8 +1,10 @@
 package kr.gravy.gravystudy.auth.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import kr.gravy.gravystudy.auth.entity.User;
 import kr.gravy.gravystudy.configuration.properties.JwtProperties;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +13,6 @@ import java.security.Key;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
-import java.util.UUID;
 
 @Component
 public class JWTUtil {
@@ -25,19 +26,20 @@ public class JWTUtil {
         this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.secret()));
     }
 
-    public String createAccessToken(UUID userPublicId) {
-        return createToken(userPublicId, ACCESS_TOKEN_EXPIRATION);
+    public String createAccessToken(User user) {
+        return createToken(user, ACCESS_TOKEN_EXPIRATION);
     }
 
-    public String createRefreshToken(UUID userPublicId) {
-        return createToken(userPublicId, REFRESH_TOKEN_EXPIRATION);
+    public String createRefreshToken(User user) {
+        return createToken(user, REFRESH_TOKEN_EXPIRATION);
     }
 
-    private String createToken(UUID userPublicId, Duration duration) {
+    private String createToken(User user, Duration duration) {
         Instant now = Instant.now();
 
         return Jwts.builder()
-                .subject(userPublicId.toString())
+                .subject(user.getPublicId().toString())
+                .claim("grade", user.getGrade().name())
                 .issuer("Gravy")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(duration)))
@@ -54,13 +56,12 @@ public class JWTUtil {
                 .getExpiration();
     }
 
-    public UUID validateAndGetSubjectAsUUID(String token) {
-        String sub = Jwts.parser()
+    public Claims validateAndGetClaims(String token) {
+        return Jwts.parser()
                 .verifyWith((SecretKey) key)
                 .build()
                 .parseSignedClaims(token)
-                .getPayload()
-                .getSubject();
-        return UUID.fromString(sub);
+                .getPayload();
+
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auth/mapper/UserMapper.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/mapper/UserMapper.java
@@ -15,8 +15,6 @@ public interface UserMapper {
 
     boolean existsAlreadyEmail(@Param("email") String email);
 
-    Optional<Grade> getUserGradeByPublicId(@Param("publicId") UUID userPublicId);
-
     Optional<User> getUserByRefreshToken(@Param("refreshToken") String refreshToken);
 
     Optional<User> getUserByPublicId(@Param("publicId") UUID userPublicId);

--- a/src/main/java/kr/gravy/gravystudy/auth/resolver/AuthenticationUserArgumentResolver.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/resolver/AuthenticationUserArgumentResolver.java
@@ -1,0 +1,53 @@
+package kr.gravy.gravystudy.auth.resolver;
+
+import kr.gravy.gravystudy.auth.entity.User;
+import kr.gravy.gravystudy.auth.mapper.UserMapper;
+import kr.gravy.gravystudy.common.exception.GravyException;
+import kr.gravy.gravystudy.common.exception.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // 1. @AuthenticationPrincipal 어노테이션이 있는지 확인
+        boolean hasAnnotation = parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+
+        // 2. 파라미터 타입이 User인지 확인
+        boolean isUserType = User.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasAnnotation && isUserType;
+    }
+
+    @Override
+    public User resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        // SecurityContext에서 인증 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new GravyException(Status.AUTHENTICATION_FAILED);
+        }
+
+        // Principal은 UUID (JWTAuthenticationFilter에서 저장한 값)
+        UUID userPublicId = (UUID) authentication.getPrincipal();
+
+        // DB에서 User 조회
+        return userMapper.getUserByPublicId(userPublicId)
+                .orElseThrow(() -> new GravyException(Status.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auth/service/AuthService.java
+++ b/src/main/java/kr/gravy/gravystudy/auth/service/AuthService.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Objects;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -72,9 +71,8 @@ public class AuthService {
 
         user.validatePassword(passwordEncoder, request.password());
 
-        UUID userPublicId = user.getPublicId();
-        String accessToken = jwtUtil.createAccessToken(userPublicId);
-        String refreshToken = jwtUtil.createRefreshToken(userPublicId);
+        String accessToken = jwtUtil.createAccessToken(user);
+        String refreshToken = jwtUtil.createRefreshToken(user);
 
         final LocalDateTime now = LocalDateTime.now();
         Date refreshTokenExpiredDate = jwtUtil.getExpiration(refreshToken);
@@ -102,8 +100,8 @@ public class AuthService {
                 .orElseThrow(() -> new GravyException(Status.USER_NOT_FOUND));
 
         final LocalDateTime now = LocalDateTime.now();
-        String accessToken = jwtUtil.createAccessToken(user.getPublicId());
-        String refreshToken = jwtUtil.createRefreshToken(user.getPublicId());
+        String accessToken = jwtUtil.createAccessToken(user);
+        String refreshToken = jwtUtil.createRefreshToken(user);
 
         Date refreshTokenExpiredDate = jwtUtil.getExpiration(refreshToken);
         LocalDateTime refreshTokenExpiredAt = DateTimeUtil.convertToLocalDateTime(refreshTokenExpiredDate);

--- a/src/main/java/kr/gravy/gravystudy/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/gravy/gravystudy/common/exception/GlobalExceptionHandler.java
@@ -5,12 +5,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import kr.gravy.gravystudy.configuration.properties.GravyProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.FileCountLimitExceededException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -62,4 +65,29 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.badRequest().body(problemDetail);
     }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ProblemDetail> handleMultipartException(MultipartException e, HttpServletRequest request) {
+        log.error("MultipartException: {}", e.getMessage());
+
+        // 파일 개수 초과 체크
+        if (e.getCause() instanceof FileCountLimitExceededException) {
+            ProblemDetail problemDetail = TOO_MANY_IMAGES.toProblemDetail(URI.create(request.getRequestURI()));
+            return ResponseEntity.badRequest().body(problemDetail);
+        }
+
+        // 기타 multipart 에러 (파일 크기 초과 등)
+        log.warn("처리되지 않은 MultipartException: {}", e.getClass().getSimpleName());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                "파일 업로드 처리 중 오류가 발생했습니다."
+        );
+        problemDetail.setType(URI.create(gravyProperties.baseUrl() + "/errors/multipart"));
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+        problemDetail.setProperty("code", "multipart001");
+        problemDetail.setProperty("timestamp", java.time.LocalDateTime.now());
+
+        return ResponseEntity.badRequest().body(problemDetail);
+    }
+
 }

--- a/src/main/java/kr/gravy/gravystudy/common/exception/Status.java
+++ b/src/main/java/kr/gravy/gravystudy/common/exception/Status.java
@@ -35,6 +35,12 @@ public enum Status {
     INVALID_AUCTION_START_TIME(400, "auction001", "경매 시작 시간은 현재 시간 이후여야 합니다"),
     INVALID_AUCTION_END_TIME(400, "auction002", "경매 종료 시간은 시작 시간보다 늦어야 합니다"),
 
+    // === S3 관련 ===
+    S3_UPLOAD_FAILED(500, "s3001", "S3 업로드에 실패했습니다"),
+    TOO_MANY_IMAGES(400, "s3002", "업로드 가능한 이미지 수를 초과했습니다."),
+    FILE_READ_FAILED(500, "file001", "파일 읽기에 실패했습니다"),
+    FILE_TOO_LARGE(400, "file002", "파일 크기가 10MB를 초과할 수 없습니다."),
+
     // === 검증 관련 ===
     VALIDATION_FAILED(400, "valid001", "입력값 검증에 실패했습니다");
 

--- a/src/main/java/kr/gravy/gravystudy/common/exception/Status.java
+++ b/src/main/java/kr/gravy/gravystudy/common/exception/Status.java
@@ -32,9 +32,8 @@ public enum Status {
     USER_NOT_FOUND(404, "user001", "사용자를 찾을 수 없습니다"),
 
     // === 경매 관련 ===
-    AUCTION_START_TIME_TOO_EARLY(400, "auction001", "경매 시작 시간은 현재 시간보다 3분 이후여야 합니다"),
-    AUCTION_END_TIME_TOO_EARLY(400, "auction002", "경매 종료 시간은 현재 시간보다 최소 1시간 이후여야 합니다"),
-    AUCTION_TIME_RANGE_INVALID(400, "auction003", "경매 종료 시간은 시작 시간보다 늦어야 합니다"),
+    INVALID_AUCTION_START_TIME(400, "auction001", "경매 시작 시간은 현재 시간 이후여야 합니다"),
+    INVALID_AUCTION_END_TIME(400, "auction002", "경매 종료 시간은 시작 시간보다 늦어야 합니다"),
 
     // === 검증 관련 ===
     VALIDATION_FAILED(400, "valid001", "입력값 검증에 실패했습니다");

--- a/src/main/java/kr/gravy/gravystudy/common/utils/FileUtil.java
+++ b/src/main/java/kr/gravy/gravystudy/common/utils/FileUtil.java
@@ -1,0 +1,33 @@
+package kr.gravy.gravystudy.common.utils;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class FileUtil {
+
+    /**
+     * 파일명에서 확장자를 추출합니다.
+     *
+     * @param originalFileName 원본 파일명
+     * @return 확장자 (예: ".jpg"), 없으면 빈 문자열
+     * TODO:: 확장자 제약조건 리팩터링 필요
+     */
+    public String extractExtension(String originalFileName) {
+        if (originalFileName == null || !originalFileName.contains(".")) {
+            return "";
+        }
+        return originalFileName.substring(originalFileName.lastIndexOf(".")).toLowerCase();
+    }
+
+    /**
+     * S3에 저장할 고유한 파일명을 생성합니다.
+     *
+     * @param originalFileName 원본 파일명
+     * @param folder           S3 폴더명
+     * @return S3 key (예: "auctions/uuid.jpg")
+     */
+    public String generateS3Key(String originalFileName, String folder) {
+        String extension = extractExtension(originalFileName);
+        return folder + "/" + GeneratorUtil.generatePublicId() + extension;
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/configuration/aws/S3Configuration.java
+++ b/src/main/java/kr/gravy/gravystudy/configuration/aws/S3Configuration.java
@@ -1,0 +1,31 @@
+package kr.gravy.gravystudy.configuration.aws;
+
+import kr.gravy.gravystudy.configuration.properties.S3Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Configuration {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                s3Properties.accessKeyId(),
+                s3Properties.secretAccessKey()
+        );
+
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(s3Properties.region()))
+                .build();
+    }
+
+}

--- a/src/main/java/kr/gravy/gravystudy/configuration/properties/PropertiesConfiguration.java
+++ b/src/main/java/kr/gravy/gravystudy/configuration/properties/PropertiesConfiguration.java
@@ -8,7 +8,8 @@ import org.springframework.context.annotation.Configuration;
         GravyProperties.class,
         CorsProperties.class,
         JwtProperties.class,
-        MailProperties.class
+        MailProperties.class,
+        S3Properties.class
 })
 public class PropertiesConfiguration {
 }

--- a/src/main/java/kr/gravy/gravystudy/configuration/properties/S3Properties.java
+++ b/src/main/java/kr/gravy/gravystudy/configuration/properties/S3Properties.java
@@ -1,0 +1,21 @@
+package kr.gravy.gravystudy.configuration.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public record S3Properties(
+        String accessKeyId,
+        String secretAccessKey,
+        String region,
+        String bucketName,
+        String baseUrl
+) {
+    private static final String DEFAULT_S3_URL_FORMAT = "https://%s.s3.%s.amazonaws.com/%s";
+
+    public String getFileUrl(String key) {
+        if (baseUrl != null && !baseUrl.isBlank()) {
+            return baseUrl.endsWith("/") ? baseUrl + key : baseUrl + "/" + key;
+        }
+        return String.format(DEFAULT_S3_URL_FORMAT, bucketName, region, key);
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/infrastructure/aws/S3Service.java
+++ b/src/main/java/kr/gravy/gravystudy/infrastructure/aws/S3Service.java
@@ -1,0 +1,106 @@
+package kr.gravy.gravystudy.infrastructure.aws;
+
+import kr.gravy.gravystudy.common.exception.GravyException;
+import kr.gravy.gravystudy.common.exception.Status;
+import kr.gravy.gravystudy.common.utils.FileUtil;
+import kr.gravy.gravystudy.configuration.properties.S3Properties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    public static final String S3_FOLDER_NAME = "auctions";
+    private static final int MAX_IMAGE_COUNT = 3;
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    /**
+     * 파일을 S3에 업로드하고 S3 URL을 반환합니다.
+     *
+     * @param file 업로드할 파일
+     * @return S3에 저장된 파일의 URL
+     */
+    public String uploadFile(MultipartFile file) {
+        String key = FileUtil.generateS3Key(file.getOriginalFilename(), S3_FOLDER_NAME);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(s3Properties.bucketName())
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .acl(ObjectCannedACL.PUBLIC_READ) // 공개 읽기 가능
+                    .build();
+
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+
+            return s3Properties.getFileUrl(key);
+        } catch (S3Exception e) {
+            log.error("S3 업로드 실패 - 에러 코드: {}, 메시지: {}, 상태 코드: {}",
+                    e.awsErrorDetails().errorCode(),
+                    e.getMessage(),
+                    e.statusCode());
+            log.error("S3 상세 정보 - 버킷: {}, 키: {}, 리전: {}",
+                    s3Properties.bucketName(),
+                    key,
+                    s3Properties.region());
+            throw new GravyException(Status.S3_UPLOAD_FAILED);
+        } catch (IOException e) {
+            log.error("파일 읽기 실패: {}", e.getMessage());
+            throw new GravyException(Status.FILE_READ_FAILED);
+        }
+    }
+
+    /**
+     * S3에서 파일을 삭제합니다.
+     *
+     * @param imageUrl 삭제할 S3 파일의 전체 URL
+     */
+    public void deleteFile(String imageUrl) {
+        try {
+            // URL에서 key 추출
+            String key = imageUrl.substring(imageUrl.indexOf(S3_FOLDER_NAME));
+
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(s3Properties.bucketName())
+                    .key(key)
+                    .build();
+            s3Client.deleteObject(deleteRequest);
+            log.info("S3 파일 삭제 성공");
+        } catch (S3Exception e) {
+            log.error("S3 파일 삭제 실패: {}, 원인: {}", imageUrl, e.getMessage());
+        }
+
+    }
+
+    public void validatePossibleUploadImages(List<MultipartFile> images) {
+        if (images.size() > MAX_IMAGE_COUNT) {
+            throw new GravyException(Status.TOO_MANY_IMAGES);
+        }
+        for (MultipartFile image : images) {
+            if (image.getSize() > MAX_FILE_SIZE) {
+                throw new GravyException(Status.FILE_TOO_LARGE);
+            }
+        }
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,12 @@ spring:
     name: gravy
   profiles:
     active: local
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+      enabled: true
+
 
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml

--- a/src/main/resources/mapper/AuctionImageMapper.xml
+++ b/src/main/resources/mapper/AuctionImageMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.gravy.gravystudy.auction.mapper.AuctionImageMapper">
+
+    <resultMap id="AuctionImageMap" type="kr.gravy.gravystudy.auction.entity.AuctionImage">
+        <id property="id" column="id" javaType="java.lang.Long"/>
+        <result property="auctionId" column="auction_id" javaType="java.lang.Long"/>
+        <result property="imageUrl" column="image_url" javaType="java.lang.String"/>
+        <result property="displayOrder" column="display_order" javaType="int"/>
+        <result property="createdAt" column="created_at" javaType="java.time.LocalDateTime"/>
+    </resultMap>
+
+    <insert id="insertAuctionImage" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO auction_images(auction_id, image_url, display_order, created_at)
+        VALUES (#{auctionId}, #{imageUrl}, #{displayOrder}, #{createdAt})
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/AuctionMapper.xml
+++ b/src/main/resources/mapper/AuctionMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="kr.gravy.gravystudy.auction.mapper.AuctionMapper">
+
+    <resultMap id="AuctionMap" type="kr.gravy.gravystudy.auction.entity.Auction">
+        <id property="id" column="id" javaType="java.lang.Long"/>
+        <result property="sellerId" column="seller_id" javaType="java.lang.Long"/>
+        <result property="title" column="title" javaType="java.lang.String"/>
+        <result property="description" column="description" javaType="java.lang.String"/>
+        <result property="category" column="category" javaType="kr.gravy.gravystudy.auction.model.Category"/>
+        <result property="startingPrice" column="starting_price" javaType="java.lang.Long"/>
+        <result property="minBidIncrement" column="min_bid_increment" javaType="java.lang.Long"/>
+        <result property="auctionStartTime" column="auction_start_time" javaType="java.time.LocalDateTime"/>
+        <result property="auctionEndTime" column="auction_end_time" javaType="java.time.LocalDateTime"/>
+        <result property="createdAt" column="created_at" javaType="java.time.LocalDateTime"/>
+    </resultMap>
+
+    <select id="getAuctionById" resultMap="AuctionMap">
+        SELECT *
+        FROM auction
+        WHERE id = #{id}
+    </select>
+
+    <insert id="insertAuction" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO auction(seller_id, title, description, category, starting_price, min_bid_increment,
+                            auction_start_time, auction_end_time, created_at)
+        VALUES (#{sellerId}, #{title}, #{description}, #{category}, #{startingPrice}, #{minBidIncrement},
+                #{auctionStartTime}, #{auctionEndTime}, #{createdAt})
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/AuctionMapper.xml
+++ b/src/main/resources/mapper/AuctionMapper.xml
@@ -19,13 +19,13 @@
 
     <select id="getAuctionById" resultMap="AuctionMap">
         SELECT *
-        FROM auction
+        FROM auctions
         WHERE id = #{id}
     </select>
 
     <insert id="insertAuction" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO auction(seller_id, title, description, category, starting_price, min_bid_increment,
-                            auction_start_time, auction_end_time, created_at)
+        INSERT INTO auctions(seller_id, title, description, category, starting_price, min_bid_increment,
+                             auction_start_time, auction_end_time, created_at)
         VALUES (#{sellerId}, #{title}, #{description}, #{category}, #{startingPrice}, #{minBidIncrement},
                 #{auctionStartTime}, #{auctionEndTime}, #{createdAt})
     </insert>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -27,12 +27,6 @@
                        WHERE email = #{email})
     </select>
 
-    <select id="getUserGradeByPublicId" resultType="kr.gravy.gravystudy.auth.model.Grade">
-        SELECT grade
-        FROM gravy_user
-        WHERE public_id = #{publicId}
-    </select>
-
     <select id="getUserByRefreshToken" resultMap="UserMap">
         SELECT u.*
         FROM refresh_token AS r


### PR DESCRIPTION
- 경매 등록 API 엔드포인트 구현 (multipart/form-data)
  - AWS S3 이미지 업로드 기능 구현 (최대 3개, 10MB 제한)
  - S3 업로드 실패 시 롤백 기능 구현

  TODO: 이미지 업로드 보안 강화 필요

  ### 현재 문제
  - 파일 확장자만 검증, Content-Type 미검증
  - Path Traversal 공격 방지 로직 없음
  - 악성 파일(.exe, .pdf)을 이미지로 위장 가능

  ### 구현해야 할 항목
  - [ ] ImageContentType Enum 생성 (JPEG, PNG, GIF, WEBP)
  - [ ] FileUtil 보안 강화 (Path Traversal 방지)
  - [ ] S3Service Content-Type 검증 추가
  - [ ] Status 에러 코드 추가 (INVALID_IMAGE_TYPE 등)

  ### 참고
  - CLAUDE.md 240-313 라인 참고