### PR TITLE
feature/2 경매 목록 조회 API 구현

### DIFF
--- a/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/controller/AuctionController.java
@@ -1,6 +1,7 @@
 package kr.gravy.gravystudy.auction.controller;
 
 import jakarta.validation.Valid;
+import kr.gravy.gravystudy.auction.dto.AuctionListDto;
 import kr.gravy.gravystudy.auction.dto.AuctionRegistrationDto;
 import kr.gravy.gravystudy.auction.service.AuctionService;
 import kr.gravy.gravystudy.auth.entity.User;
@@ -10,10 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -31,5 +29,12 @@ public class AuctionController {
             @Valid @ModelAttribute AuctionRegistrationDto.Request request,
             @RequestPart(value = "image", required = false) List<MultipartFile> images) {
         return ResponseEntity.status(HttpStatus.CREATED).body(auctionService.registerAuction(user, request, images));
+    }
+
+    @GetMapping("/api/v1/auctions")
+    public ResponseEntity<AuctionListDto.Response> getAuctions(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "8") int size) {
+        return ResponseEntity.ok(auctionService.getAuctions(page, size));
     }
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionListDto.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionListDto.java
@@ -1,0 +1,65 @@
+package kr.gravy.gravystudy.auction.dto;
+
+import kr.gravy.gravystudy.auction.entity.Auction;
+import kr.gravy.gravystudy.auction.model.AuctionStatus;
+import kr.gravy.gravystudy.auction.model.Category;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AuctionListDto {
+
+    /**
+     * 경매 목록 조회 응답 DTO
+     *
+     * @param serverTime 서버 현재 시간 (클라이언트 시간 보정용)
+     * @param auctions   경매 목록
+     * @param totalCount 전체 경매 개수
+     * @param page       현재 페이지
+     * @param size       페이지당 개수
+     */
+    public record Response(
+            LocalDateTime serverTime,
+            List<AuctionItem> auctions,
+            Long totalCount,
+            Integer page,
+            Integer size
+    ) {
+    }
+
+    /**
+     * 경매 개별 항목 DTO
+     *
+     * @param id               경매 ID
+     * @param title            경매 제목
+     * @param category         카테고리
+     * @param status           경매 상태 (서버에서 계산)
+     * @param currentPrice     현재가 (지금은 시작가와 동일)
+     * @param auctionStartTime 경매 시작 시간
+     * @param auctionEndTime   경매 종료 시간
+     * @param thumbnailUrl     대표 이미지 URL
+     */
+    public record AuctionItem(
+            Long id,
+            String title,
+            Category category,
+            AuctionStatus status,
+            Long currentPrice,
+            LocalDateTime auctionStartTime,
+            LocalDateTime auctionEndTime,
+            String thumbnailUrl
+    ) {
+        public static AuctionItem from(Auction auction, String thumbnailUrl) {
+            return new AuctionItem(
+                    auction.getId(),
+                    auction.getTitle(),
+                    auction.getCategory(),
+                    AuctionStatus.from(auction.getAuctionStartTime(), auction.getAuctionEndTime()),
+                    auction.getStartingPrice(),
+                    auction.getAuctionStartTime(),
+                    auction.getAuctionEndTime(),
+                    thumbnailUrl
+            );
+        }
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionThumbnail.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/dto/AuctionThumbnail.java
@@ -1,0 +1,7 @@
+package kr.gravy.gravystudy.auction.dto;
+
+public record AuctionThumbnail(
+        Long auctionId,
+        String imageUrl
+) {
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionImageMapper.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionImageMapper.java
@@ -1,8 +1,20 @@
 package kr.gravy.gravystudy.auction.mapper;
 
+import kr.gravy.gravystudy.auction.dto.AuctionThumbnail;
 import kr.gravy.gravystudy.auction.entity.AuctionImage;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 public interface AuctionImageMapper {
 
     void insertAuctionImage(AuctionImage auctionImage);
+
+    /**
+     * 여러 경매의 첫 번째 이미지를 한 번에 조회합니다.
+     *
+     * @param auctionIdList 경매 ID 목록
+     * @return 경매 썸네일 목록
+     */
+    List<AuctionThumbnail> findFirstImagesByAuctionIdList(@Param("auctionIdList") List<Long> auctionIdList);
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionMapper.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/mapper/AuctionMapper.java
@@ -1,8 +1,22 @@
 package kr.gravy.gravystudy.auction.mapper;
 
 import kr.gravy.gravystudy.auction.entity.Auction;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 public interface AuctionMapper {
 
     void insertAuction(Auction auction);
+
+    /**
+     * 경매 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param offset 시작 위치
+     * @param limit  조회 개수
+     * @return 경매 목록
+     */
+    List<Auction> findAuctionsWithPagination(@Param("offset") int offset, @Param("limit") int limit);
+
+    long countTotalAuctions();
 }

--- a/src/main/java/kr/gravy/gravystudy/auction/model/AuctionStatus.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/model/AuctionStatus.java
@@ -1,0 +1,37 @@
+package kr.gravy.gravystudy.auction.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuctionStatus {
+    SCHEDULED("경매 예정"),
+    ONGOING("경매 진행중"),
+    ENDED("경매 종료");
+
+    private final String description;
+
+    /**
+     * 경매 시작/종료 시간을 기준으로 현재 상태를 계산합니다.
+     *
+     * @param startTime 경매 시작 시간
+     * @param endTime   경매 종료 시간
+     * @return 계산된 경매 상태
+     */
+    public static AuctionStatus from(LocalDateTime startTime, LocalDateTime endTime) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(startTime)) {
+            return SCHEDULED;
+        }
+
+        if (now.isAfter(endTime)) {
+            return ENDED;
+        }
+
+        return ONGOING;
+    }
+}

--- a/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
+++ b/src/main/java/kr/gravy/gravystudy/auction/service/AuctionService.java
@@ -1,6 +1,8 @@
 package kr.gravy.gravystudy.auction.service;
 
+import kr.gravy.gravystudy.auction.dto.AuctionListDto;
 import kr.gravy.gravystudy.auction.dto.AuctionRegistrationDto;
+import kr.gravy.gravystudy.auction.dto.AuctionThumbnail;
 import kr.gravy.gravystudy.auction.entity.Auction;
 import kr.gravy.gravystudy.auction.entity.AuctionImage;
 import kr.gravy.gravystudy.auction.mapper.AuctionImageMapper;
@@ -16,6 +18,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -106,5 +110,41 @@ public class AuctionService {
                 log.error("S3 롤백 실패 (수동 처리 필요): {}", imageUrl, e);
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    public AuctionListDto.Response getAuctions(int page, int size) {
+        int offset = calculateOffset(page, size);
+
+        List<Auction> auctions = auctionMapper.findAuctionsWithPagination(offset, size);
+        long totalCount = auctionMapper.countTotalAuctions();
+
+        if (auctions.isEmpty()) {
+            return new AuctionListDto.Response(LocalDateTime.now(), List.of(), totalCount, page, size);
+        }
+
+        List<Long> auctionIdList = auctions.stream()
+                .map(Auction::getId)
+                .toList();
+
+        Map<Long, String> thumbnailMap = auctionImageMapper
+                .findFirstImagesByAuctionIdList(auctionIdList).stream()
+                .collect(Collectors.toMap(
+                        AuctionThumbnail::auctionId,
+                        AuctionThumbnail::imageUrl
+                ));
+
+        List<AuctionListDto.AuctionItem> auctionItems = auctions.stream()
+                .map(auction -> {
+                    String thumbnailUrl = thumbnailMap.get(auction.getId());
+                    return AuctionListDto.AuctionItem.from(auction, thumbnailUrl);
+                })
+                .toList();
+
+        return new AuctionListDto.Response(LocalDateTime.now(), auctionItems, totalCount, page, size);
+    }
+
+    private int calculateOffset(int page, int size) {
+        return (page - 1) * size;
     }
 }

--- a/src/main/resources/mapper/AuctionImageMapper.xml
+++ b/src/main/resources/mapper/AuctionImageMapper.xml
@@ -16,4 +16,14 @@
         INSERT INTO auction_images(auction_id, image_url, display_order, created_at)
         VALUES (#{auctionId}, #{imageUrl}, #{displayOrder}, #{createdAt})
     </insert>
+
+    <select id="findFirstImagesByAuctionIdList" resultType="kr.gravy.gravystudy.auction.dto.AuctionThumbnail">
+        SELECT auction_id, image_url
+        FROM auction_images
+        WHERE auction_id IN
+        <foreach collection="auctionIdList" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+        AND display_order = 0
+    </select>
 </mapper>

--- a/src/main/resources/mapper/AuctionMapper.xml
+++ b/src/main/resources/mapper/AuctionMapper.xml
@@ -29,4 +29,16 @@
         VALUES (#{sellerId}, #{title}, #{description}, #{category}, #{startingPrice}, #{minBidIncrement},
                 #{auctionStartTime}, #{auctionEndTime}, #{createdAt})
     </insert>
+
+    <select id="findAuctionsWithPagination" resultMap="AuctionMap">
+        SELECT *
+        FROM auctions
+        ORDER BY created_at DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countTotalAuctions" resultType="long">
+        SELECT COUNT(*)
+        FROM auctions
+    </select>
 </mapper>


### PR DESCRIPTION
  - 페이지네이션
  - GET /api/v1/auctions?page=1&size=8 엔드포인트 추가
  - 서버 현재 시간 포함 (클라이언트 시간 오프셋 계산용)
  - 경매 상태 실시간 계산 (경매 예정/진행중/종료)
  - 썸네일 이미지 URL 포함
  - N+1 문제 해결
    - IN 절로 썸네일 일괄 조회
    - AuctionThumbnail DTO 도입으로 타입 안전성 확보


---
 ### 1. 실시간 상태 업데이트 미지원
  **현재:** 프론트가 조회 요청을 해야 경매 상태 갱신
  **문제:** 사용자가 페이지를 새로고침하지 않으면 상태 변경 감지 불가
  **해결 방안:**
  - [ ] WebSocket/SSE를 통한 실시간 상태 푸시 구현
  - [ ] 프론트에서 serverTime 기준 클라이언트 타이머 구현 (임시 해결책)

  ### 2. 경매 시간 검증 로직 부재 (보안 이슈)
  **현재:** 조회 API에서만 상태 계산, 입찰/낙찰 API에는 시간 검증 없음
  **문제:** 경매 종료 후에도 악의적으로 입찰 가능
  **해결 방안:**
  - [ ] 입찰 API에 경매 시간 검증 로직 추가
    - `if (now.isAfter(auction.getAuctionEndTime())) throw new GravyException(AUCTION_ENDED);`
    - `if (now.isBefore(auction.getAuctionStartTime())) throw new GravyException(AUCTION_NOT_STARTED);`
  - [ ] 낙찰 API에도 동일한 검증 적용
  - [ ] AuctionStatus enum에 `validateAuctionTime()` 메서드 추가 고려

  ---
  추가 제안: AuctionStatus에 검증 메서드 추가